### PR TITLE
fix: resolve package version conflicts causing build failures

### DIFF
--- a/backend/src/Portfolio.Api/Portfolio.Api.csproj
+++ b/backend/src/Portfolio.Api/Portfolio.Api.csproj
@@ -15,20 +15,20 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
     <PackageReference Include="Google.Apis.Auth" Version="1.70.0" />
     <PackageReference Include="MediatR" Version="13.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.19" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.19" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.19" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.19" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.19" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.19" />
     <PackageReference Include="Microsoft.Data.Analysis" Version="0.22.2" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.19" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.19">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.19" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="RestSharp" Version="112.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />

--- a/backend/src/Portfolio.Application/Portfolio.Application.csproj
+++ b/backend/src/Portfolio.Application/Portfolio.Application.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="AutoMapper" Version="15.0.1" />
     <PackageReference Include="CSharpFunctionalExtensions" Version="3.6.0" />    
     <PackageReference Include="CsvHelper" Version="33.1.0" />    
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.19" />
     <PackageReference Include="Microsoft.Data.Analysis" Version="0.22.2" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.11" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
@@ -23,7 +23,7 @@
     <PackageReference Include="YahooFinanceApi" Version="2.3.3" />
     <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />      
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.19" />      
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/Portfolio.Domain/Portfolio.Domain.csproj
+++ b/backend/src/Portfolio.Domain/Portfolio.Domain.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="CSharpFunctionalExtensions" Version="3.6.0" />
-    <PackageReference Include="MediaTr" Version="13.0.0" />
+    <PackageReference Include="MediatR" Version="13.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/backend/src/Portfolio.Infrastructure/Portfolio.Infrastructure.csproj
+++ b/backend/src/Portfolio.Infrastructure/Portfolio.Infrastructure.csproj
@@ -14,20 +14,20 @@
   <PackageReference Include="CSharpFunctionalExtensions" Version="3.6.0" />
   <PackageReference Include="CsvHelper" Version="33.1.0" />
   <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
-  <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.11" />
+  <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.19" />
   <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.19" />
-  <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.11" />
+  <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.19" />
    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.19" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.19" />
     <PackageReference Include="Microsoft.Data.Analysis" Version="0.22.2" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.19" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.19">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.11">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.19" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.19">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/backend/tests/Portfolio.App.Tests/Portfolio.App.Tests.csproj
+++ b/backend/tests/Portfolio.App.Tests/Portfolio.App.Tests.csproj
@@ -15,14 +15,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.19" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.19" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.19" />
     <PackageReference Include="Microsoft.Data.Analysis" Version="0.22.2" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.19" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.19" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.19" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.4.0" />

--- a/backend/tests/Portfolio.Transactions.Importers.Tests/Portfolio.Transactions.Importers.Tests.csproj
+++ b/backend/tests/Portfolio.Transactions.Importers.Tests/Portfolio.Transactions.Importers.Tests.csproj
@@ -16,8 +16,8 @@
     </PackageReference>
     <PackageReference Include="CSharpFunctionalExtensions" Version="3.6.0" />
     <PackageReference Include="Microsoft.Data.Analysis" Version="0.22.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.19" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.19" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="FluentAssertions" Version="8.6.0" />


### PR DESCRIPTION
## Summary
Fixes critical package version conflicts that were causing CI build failures after the bulk dependency update.

## Root Causes
1. **Typo in Domain project**: `MediaTr` instead of `MediatR` 
2. **Version mismatches**: ASP.NET Core and EntityFrameworkCore packages had inconsistent versions across projects
3. **Dependency conflicts**: Package downgrades were detected due to version inconsistencies

## Changes
- ✅ Fix `MediaTr` → `MediatR` typo in `Portfolio.Domain.csproj`
- ✅ Align all ASP.NET Core packages to version **8.0.19**
- ✅ Update all EntityFrameworkCore packages to version **8.0.19** 
- ✅ Ensure consistent package versions across all projects

## Validation
- ✅ .NET build succeeds with `dotnet build --configuration Release`
- ✅ Only nullability warnings remain (expected)
- ✅ No package downgrade errors

## Impact
This resolves the CI build failures and ensures the dependency updates from PR #69 work correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)